### PR TITLE
Workaround Windows 10 Calendar & Mail App - Prevent Sync

### DIFF
--- a/sabre/dav/lib/CalDAV/Plugin.php
+++ b/sabre/dav/lib/CalDAV/Plugin.php
@@ -583,6 +583,11 @@ class Plugin extends DAV\ServerPlugin {
                 // should have set depth to 1. We're implementing a workaround here
                 // to deal with this.
                 $depth = 1;
+            } else if (strpos($this->server->httpRequest->getHeader('User-Agent'), 'MSFT-WIN') === 0) {
+                // Windows 10 (Calendar & Mail app) since build 1511 Update also incorrectly
+                // supplies depth as 0, when it actually should have set depth to 1.
+                // We're implementing a workaround here to deal with this.
+                $depth = 1;
             } else {
                 throw new BadRequest('A calendar-query REPORT on a calendar with a Depth: 0 is undefined. Set Depth to 1');
             }


### PR DESCRIPTION
Since Windows 10 built 1511 the builtin Calendar App supplies a new user agent MSFT-WIN-3/..... and supplies an incorrect depth of 0.
This breaks the complete calendar sync for all Windows 10 Calendar app users.
A workaround is added similar to the Windows Phone work around to set the supplied depth to 1 again.
